### PR TITLE
TEST-322 OpenId UseCookiesTest fix

### DIFF
--- a/payara/openid/pom.xml
+++ b/payara/openid/pom.xml
@@ -2,7 +2,7 @@
 <!--
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
- Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
 
  The contents of this file are subject to the terms of either the GNU
  General Public License Version 2 only ("GPL") or the Common Development
@@ -50,4 +50,13 @@
     <name>Vendor EE: Payara - OpenId Connect</name>
     <packaging>war</packaging>
     
+    <dependencies>
+        <dependency>
+            <groupId>org.vendoree</groupId>
+            <artifactId>test-utils</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/payara/openid/src/test/java/fish/payara/security/oidc/test/UseCookiesTest.java
+++ b/payara/openid/src/test/java/fish/payara/security/oidc/test/UseCookiesTest.java
@@ -1,7 +1,7 @@
 /*
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- *  Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+ *  Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  *  The contents of this file are subject to the terms of either the GNU
  *  General Public License Version 2 only ("GPL") or the Common Development
@@ -41,8 +41,14 @@ package fish.payara.security.oidc.test;
 
 import com.gargoylesoftware.htmlunit.WebClient;
 import static fish.payara.security.annotations.OpenIdAuthenticationDefinition.OPENID_MP_USE_SESSION;
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
+import java.security.KeyPair;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -53,6 +59,18 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import static org.omnifaces.utils.security.Certificates.createTempJKSKeyStore;
+import org.vendoree.ServerOperations;
+import static org.omnifaces.utils.Lang.isEmpty;
+import static org.omnifaces.utils.security.Certificates.createTempJKSKeyStore;
+import static org.omnifaces.utils.security.Certificates.createTempJKSTrustStore;
+import static org.omnifaces.utils.security.Certificates.generateRandomRSAKeys;
+import static org.omnifaces.utils.security.Certificates.getCertificateChainFromServer;
+import static org.vendoree.ServerOperations.addCertificateToContainerTrustStore;
+import static org.vendoree.ServerOperations.addContainerSystemProperty;
+import static org.vendoree.ServerOperations.createSelfSignedCertificate;
+import static org.vendoree.ServerOperations.enableSSLDebug;
+import static org.vendoree.ServerOperations.getHostFromCertificate;
 
 /**
  *
@@ -67,10 +85,9 @@ public class UseCookiesTest {
     @ArquillianResource
     private URL base;
 
-    @Before
-    public void init() {
-        webClient = new WebClient();
-    }
+    private URL baseHttps;
+
+    private static String clientKeyStorePath;
 
     @Deployment(name = "openid-server")
     public static WebArchive createServerDeployment() {
@@ -79,16 +96,97 @@ public class UseCookiesTest {
 
     @Deployment(name = "openid-client")
     public static WebArchive createClientDeployment() {
+        System.out.println("\n*********** DEPLOYMENT START ***************************");
+
+        Security.addProvider(new BouncyCastleProvider());
+
+        // Enable to get detailed logging about the SSL handshake on the client
+        // For an explanation of the TLS handshake see: https://tls.ulfheim.net
+        if (System.getProperty("ssl.debug") != null) {
+            enableSSLDebug();
+        }
+
+        System.out.println("################################################################");
+
+        // ### Generate keys for the client, create a certificate, and add those to a new local key store
+        // Generate a Private/Public key pair for the client
+        KeyPair clientKeyPair = generateRandomRSAKeys();
+
+        // Create a certificate containing the client public key and signed with the private key
+        X509Certificate clientCertificate = createSelfSignedCertificate(clientKeyPair);
+
+        // Create a new local key store containing the client private key and the certificate
+        clientKeyStorePath = createTempJKSKeyStore(clientKeyPair.getPrivate(), clientCertificate);
+
+        // Enable to get detailed logging about the SSL handshake on the server
+        if (System.getProperty("ssl.debug") != null) {
+            System.out.println("Setting server SSL debug on");
+            addContainerSystemProperty("javax.net.debug", "ssl:handshake");
+        }
+
+        // Only test TLS v1.2 for now
+        System.setProperty("jdk.tls.client.protocols", "TLSv1.2");
+
+        // Add the client certificate that we just generated to the trust store of the server.
+        // That way the server will trust our certificate.
+        // Set the actual domain used with -Dpayara_domain=[domain name]
+        addCertificateToContainerTrustStore(clientCertificate);
+
         StringAsset mpConfig = new StringAsset(OPENID_MP_USE_SESSION + "=" + Boolean.FALSE.toString());
         return OpenIdTestUtil
                 .createClientDeployment()
                 .addAsWebInfResource(mpConfig, "classes/META-INF/microprofile-config.properties");
     }
 
+    @Before
+    public void setup() throws FileNotFoundException, IOException {
+        webClient = new WebClient();
+        baseHttps = ServerOperations.toContainerHttps(base);
+        if (baseHttps == null) {
+            throw new IllegalStateException("No https URL could be created from " + base);
+        }
+
+        // ### Ask the server for its certificate and add that to a new local trust store
+        // Server -> client : the trust store certificates are used to validate the certificate sent
+        // by the server
+        X509Certificate[] serverCertificateChain = getCertificateChainFromServer(baseHttps.getHost(), baseHttps.getPort());
+
+        if (!isEmpty(serverCertificateChain)) {
+
+            System.out.println("Obtained certificate from server. Storing it in client trust store");
+
+            String trustStorePath = createTempJKSTrustStore(serverCertificateChain);
+
+            System.out.println("Reading trust store from: " + trustStorePath);
+
+            webClient.getOptions().setSSLTrustStore(new File(trustStorePath).toURI().toURL(), "changeit", "jks");
+
+            // If the use.cnHost property is we try to extract the host from the server
+            // certificate and use exactly that host for our requests.
+            // This is needed if a server is listening to multiple host names, for instance
+            // localhost and example.com. If the certificate is for example.com, we can't
+            // localhost for the request, as that will not be accepted.
+            if (System.getProperty("use.cnHost") != null) {
+                System.out.println("use.cnHost set. Trying to grab CN from certificate and use as host for requests.");
+                baseHttps = getHostFromCertificate(serverCertificateChain, baseHttps);
+            }
+        } else {
+            System.out.println("Could not obtain certificates from server. Continuing without custom truststore");
+        }
+
+        System.out.println("Using client key store from: " + clientKeyStorePath);
+
+        // Client -> Server : the key store's private keys and certificates are used to sign
+        // and sent a reply to the server
+        webClient.getOptions().setSSLClientCertificate(new File(clientKeyStorePath).toURI().toURL(), "changeit", "jks");
+
+        System.out.println("*********** SETUP DONE ***************************\n");
+    }
+
     @Test
     @RunAsClient
     public void testOpenIdConnect() throws IOException {
-        OpenIdTestUtil.testOpenIdConnect(webClient, base);
+        OpenIdTestUtil.testOpenIdConnect(webClient, baseHttps);
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 
 		<!-- Micro implementation versions (these are downloaded and installed 
 			in these versions by Maven for the CI profiles) -->
-		<payara.version>5.183-SNAPSHOT</payara.version>
+		<payara.version>5.192-SNAPSHOT</payara.version>
 		<payara.micro.version>5.182</payara.micro.version>
 		<liberty.version>17.0.0.4</liberty.version>
 		<wildfly.version>2018.4.1</wildfly.version>
@@ -208,12 +208,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>net.sourceforge.htmlunit</groupId>
-			<artifactId>htmlunit</artifactId>
-			<version>2.30</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>rhino</groupId>
 			<artifactId>js</artifactId>
 			<version>1.7R2</version>
@@ -231,6 +225,42 @@
 			<version>1.7.0</version>
 			<scope>test</scope>
 		</dependency>
+
+                <dependency>
+                    <groupId>com.nimbusds</groupId>
+                    <artifactId>nimbus-jose-jwt</artifactId>
+                    <version>7.1</version>
+                </dependency>
+                <dependency>
+                    <groupId>net.sourceforge.htmlunit</groupId>
+                    <artifactId>htmlunit</artifactId>
+                    <version>2.35.0</version>
+                </dependency>
+                <dependency>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                    <version>1.2</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.httpcomponents</groupId>
+                    <artifactId>httpclient</artifactId>
+                    <version>4.5.8</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.omnifaces</groupId>
+                    <artifactId>omniutils</artifactId>
+                    <version>0.11</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcprov-jdk15on</artifactId>
+                    <version>1.61</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk15on</artifactId>
+                    <version>1.61</version>
+                </dependency>
 	</dependencies>
 
 

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -26,11 +26,6 @@
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-api-maven</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.nimbusds</groupId>
-            <artifactId>nimbus-jose-jwt</artifactId>
-            <version>5.1</version>
-        </dependency>
     </dependencies>
     
 </project>

--- a/test-utils/src/main/java/org/vendoree/CliCommands.java
+++ b/test-utils/src/main/java/org/vendoree/CliCommands.java
@@ -22,7 +22,12 @@ public class CliCommands {
     private static final Logger logger = Logger.getLogger(CliCommands.class.getName()); 
     private static final String OS = System.getProperty("os.name").toLowerCase();
 
+
     public static int payaraGlassFish(List<String> cliCommands) {
+        return payaraGlassFish(cliCommands, null);
+    }
+
+    public static int payaraGlassFish(List<String> cliCommands, List<String> output) {
         
         String gfHome = System.getProperty("glassfishRemote_gfHome");
         if (gfHome == null) {
@@ -60,13 +65,14 @@ public class CliCommands {
             return 
                 waitToFinish(
                     readAllInput(
+                        output,
                         destroyAtShutDown(
                             processBuilder.start())));
         } catch (IOException e) {
             return -1;
         }
     }
-    
+
     public static Process destroyAtShutDown(final Process process) {
         getRuntime().addShutdownHook(new Thread(new Runnable() {
             @Override
@@ -86,11 +92,15 @@ public class CliCommands {
         return process;
     }
     
-    public static Process readAllInput(Process process) {
+    public static Process readAllInput(List<String> output, Process process) {
         // Read any output from the process
         try (Scanner scanner = new Scanner(process.getInputStream())) {
             while (scanner.hasNextLine()) {
-                System.out.println(scanner.nextLine());
+                String nextLine = scanner.nextLine();
+                System.out.println(nextLine);
+                if (output != null) {
+                    output.add(nextLine);
+                }
             }
         }
         

--- a/test-utils/src/main/java/org/vendoree/ServerOperations.java
+++ b/test-utils/src/main/java/org/vendoree/ServerOperations.java
@@ -1,8 +1,43 @@
 package org.vendoree;
 
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.logging.impl.Jdk14Logger;
+import static java.math.BigInteger.ONE;
+import static java.time.Instant.now;
+import static java.time.temporal.ChronoUnit.DAYS;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
+import java.security.Security;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import static java.util.logging.Level.FINEST;
+import java.util.logging.Logger;
+
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.omnifaces.utils.security.Certificates;
 
 /**
  * Various high level Java EE 7 samples specific operations to execute against
@@ -13,6 +48,8 @@ import java.util.List;
  */
 public class ServerOperations {
 
+    private static final Logger logger = Logger.getLogger(ServerOperations.class.getName());
+
     /**
      * Add the default test user and credentials to the identity store of
      * supported containers
@@ -21,7 +58,6 @@ public class ServerOperations {
 
         // TODO: abstract adding container managed users to utility class
         // TODO: consider PR for sending CLI commands to Arquillian
-
         String javaEEServer = System.getProperty("javaEEServer");
 
         if ("glassfish-remote".equals(javaEEServer) || "payara-remote".equals(javaEEServer)) {
@@ -48,8 +84,301 @@ public class ServerOperations {
         }
 
         // TODO: support other servers than Payara and GlassFish
-
         // WildFly ./bin/add-user.sh -a -u u1 -p p1 -g g1
+    }
+
+    public static void addCertificateToContainerTrustStore(Certificate clientCertificate) {
+
+        String javaEEServer = System.getProperty("javaEEServer");
+
+        if ("glassfish-remote".equals(javaEEServer) || "payara-remote".equals(javaEEServer)) {
+
+            String gfHome = System.getProperty("glassfishRemote_gfHome");
+            if (gfHome == null) {
+                logger.info("glassfishRemote_gfHome not specified");
+                return;
+            }
+
+            Path gfHomePath = Paths.get(gfHome);
+            if (!gfHomePath.toFile().exists()) {
+                logger.severe("glassfishRemote_gfHome at " + gfHome + " does not exists");
+                return;
+            }
+
+            if (!gfHomePath.toFile().isDirectory()) {
+                logger.severe("glassfishRemote_gfHome at " + gfHome + " is not a directory");
+                return;
+            }
+
+            String domain = System.getProperty("payara_domain", "domain1");
+            if (domain != null) {
+                domain = getPayaraDomainFromServer();
+                logger.info("Using domain \"" + domain + "\" obtained from server. If this is not correct use -Dpayara_domain to override.");
+            }
+
+            Path cacertsPath = gfHomePath.resolve("glassfish/domains/" + domain + "/config/cacerts.jks");
+
+            if (!cacertsPath.toFile().exists()) {
+                logger.severe("The container trust store at " + cacertsPath.toAbsolutePath() + " does not exists");
+                logger.severe("Is the domain \"" + domain + "\" correct?");
+                return;
+            }
+
+            logger.info("*** Adding certificate to container trust store: " + cacertsPath.toAbsolutePath());
+
+            KeyStore keyStore = null;
+            try (InputStream in = new FileInputStream(cacertsPath.toAbsolutePath().toFile())) {
+                keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+                keyStore.load(in, "changeit".toCharArray());
+
+                keyStore.setCertificateEntry("arquillianClientTestCert", clientCertificate);
+
+                keyStore.store(new FileOutputStream(cacertsPath.toAbsolutePath().toFile()), "changeit".toCharArray());
+            } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException | IOException e) {
+                throw new IllegalStateException(e);
+            }
+
+            restartContainer(domain);
+        } else {
+            if (javaEEServer == null) {
+                System.out.println("javaEEServer not specified");
+            } else {
+                System.out.println(javaEEServer + " not supported");
+            }
+        }
+
+    }
+
+    public static URL toContainerHttps(URL url) {
+        if ("https".equals(url.getProtocol())) {
+            return url;
+        }
+
+        String javaEEServer = System.getProperty("javaEEServer");
+
+        // String protocol, String host, int port, String file
+        if ("glassfish-remote".equals(javaEEServer) || "payara-remote".equals(javaEEServer)) {
+
+            try {
+                URL httpsUrl = new URL(
+                        "https",
+                        url.getHost(),
+                        8181,
+                        url.getFile()
+                );
+
+                System.out.println("Changing base URL from " + url + " into " + httpsUrl);
+
+                return httpsUrl;
+
+            } catch (MalformedURLException e) {
+                System.out.println("Failure creating HTTPS URL");
+                e.printStackTrace();
+                logger.log(Level.SEVERE, "Failure creating HTTPS URL", e);
+            }
+
+        } else {
+            if (javaEEServer == null) {
+                System.out.println("javaEEServer not specified");
+            } else {
+                System.out.println(javaEEServer + " not supported");
+            }
+        }
+
+        return null;
+    }
+
+    private static String getPayaraDomainFromServer() {
+        System.out.println("Getting Payara domain from server");
+
+        List<String> output = new ArrayList<>();
+        List<String> cmd = new ArrayList<>();
+
+        cmd.add("list-domains");
+
+        CliCommands.payaraGlassFish(cmd, output);
+
+        String domain = null;
+        for (String line : output) {
+            if (line.contains(" not running")) {
+                continue;
+            }
+
+            if (line.endsWith(" running")) {
+                domain = line.substring(0, line.lastIndexOf(" running"));
+                break;
+            }
+        }
+
+        return domain;
+    }
+
+    public static void addContainerSystemProperty(String key, String value) {
+        String javaEEServer = System.getProperty("javaEEServer");
+
+        if ("glassfish-remote".equals(javaEEServer) || "payara-remote".equals(javaEEServer)) {
+
+            System.out.println("Adding system property");
+
+            List<String> cmd = new ArrayList<>();
+
+            cmd.add("create-jvm-options");
+            cmd.add("-D" + key + "=\"" + value + "\"");
+
+            CliCommands.payaraGlassFish(cmd);
+
+        } else {
+            if (javaEEServer == null) {
+                System.out.println("javaEEServer not specified");
+            } else {
+                System.out.println(javaEEServer + " not supported");
+            }
+        }
+    }
+
+    public static void restartContainer() {
+        restartContainer(null);
+    }
+
+    public static void restartContainer(String domain) {
+        // Arquillian connectors can stop/start already, but not on demand by code
+
+        String javaEEServer = System.getProperty("javaEEServer");
+
+        if ("glassfish-remote".equals(javaEEServer) || "payara-remote".equals(javaEEServer)) {
+
+            System.out.println("Restarting domain");
+
+            List<String> cmd = new ArrayList<>();
+
+            cmd.add("restart-domain");
+
+            String restartDomain = domain;
+            if (restartDomain == null) {
+                restartDomain = System.getProperty("payara_domain");
+            }
+
+            if (restartDomain == null) {
+                restartDomain = getPayaraDomainFromServer();
+            }
+
+            cmd.add(restartDomain);
+
+            CliCommands.payaraGlassFish(cmd);
+
+            try {
+                Thread.sleep(2000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
+        } else {
+            if (javaEEServer == null) {
+                System.out.println("javaEEServer not specified");
+            } else {
+                System.out.println(javaEEServer + " not supported");
+            }
+        }
+    }
+
+    public static void restartContainerDebug() {
+        // Arquillian connectors can stop/start already, but not on demand by code
+
+        String javaEEServer = System.getProperty("javaEEServer");
+
+        if ("glassfish-remote".equals(javaEEServer) || "payara-remote".equals(javaEEServer)) {
+
+            System.out.println("Stopping domain");
+
+            List<String> cmd = new ArrayList<>();
+
+            cmd.add("stop-domain");
+
+            CliCommands.payaraGlassFish(cmd);
+
+            try {
+                Thread.sleep(2000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
+            System.out.println("Starting domain");
+
+            cmd = new ArrayList<>();
+
+            cmd.add("start-domain");
+
+            CliCommands.payaraGlassFish(cmd);
+
+            System.out.println("Command returned");
+
+            try {
+                Thread.sleep(10000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+
+            System.out.println("After sleep");
+        }
+    }
+
+    public static X509Certificate createSelfSignedCertificate(KeyPair keys) {
+        try {
+            Provider provider = new BouncyCastleProvider();
+            Security.addProvider(provider);
+            return new JcaX509CertificateConverter()
+                    .setProvider(provider)
+                    .getCertificate(
+                            new X509v3CertificateBuilder(
+                                    new X500Name("CN=lfoo, OU=bar, O=kaz, L=zak, ST=lak, C=UK"),
+                                    ONE,
+                                    Date.from(now()),
+                                    Date.from(now().plus(1, DAYS)),
+                                    new X500Name("CN=lfoo, OU=bar, O=kaz, L=zak, ST=lak, C=UK"),
+                                    SubjectPublicKeyInfo.getInstance(keys.getPublic().getEncoded()))
+                                    .build(
+                                            new JcaContentSignerBuilder("SHA256WithRSA")
+                                                    .setProvider(provider)
+                                                    .build(keys.getPrivate())));
+        } catch (CertificateException | OperatorCreationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    public static URL getHostFromCertificate(X509Certificate[] serverCertificateChain, URL existingURL) {
+        try {
+            URL httpsUrl = new URL(
+                    existingURL.getProtocol(),
+                    Certificates.getHostFromCertificate(serverCertificateChain),
+                    existingURL.getPort(),
+                    existingURL.getFile()
+            );
+
+            System.out.println("Changing base URL from " + existingURL + " into " + httpsUrl + "\n");
+
+            return httpsUrl;
+
+        } catch (MalformedURLException e) {
+            System.out.println("Failure creating HTTPS URL");
+            e.printStackTrace();
+
+            System.out.println("FAILED to get CN. Using existing URL: " + existingURL);
+
+            return existingURL;
+        }
+    }
+
+    public static void enableSSLDebug() {
+        System.setProperty("javax.net.debug", "ssl:handshake");
+
+        System.getProperties().put("org.apache.commons.logging.simplelog.defaultlog", "debug");
+        Logger.getLogger("com.gargoylesoftware.htmlunit.httpclient.HtmlUnitSSLConnectionSocketFactory").setLevel(FINEST);
+        Logger.getLogger("org.apache.http.conn.ssl.SSLConnectionSocketFactory").setLevel(FINEST);
+        Log logger = LogFactory.getLog(org.apache.http.conn.ssl.SSLConnectionSocketFactory.class);
+        ((Jdk14Logger) logger).getLogger().setLevel(FINEST);
+        logger = LogFactory.getLog(com.gargoylesoftware.htmlunit.httpclient.HtmlUnitSSLConnectionSocketFactory.class);
+        ((Jdk14Logger) logger).getLogger().setLevel(FINEST);
+        Logger.getGlobal().getParent().getHandlers()[0].setLevel(FINEST);
     }
 
 }


### PR DESCRIPTION
If `payara.security.openid.useSession` property set to `false`, Cookies are used for storage of OpenId state and nonce with attribute HttpOnly & Secure. So to fix the testcase base url changed to Https base url.